### PR TITLE
Splat arguments to handler instead of sending array to to handler.

### DIFF
--- a/lib/motion-kit-events/layout.rb
+++ b/lib/motion-kit-events/layout.rb
@@ -50,7 +50,7 @@ module MotionKit
             if handler.arity == 0
               handler.call
             else
-              handler.call(params)
+              handler.call(*params)
             end
           end
         end


### PR DESCRIPTION
Started using motion-kit and motion-kit-events recently and love it. 

When registering a handler with more than one parameter, I would get an ArgumentError (1 for n) exception since the handler seems to be called with a single argument, the params array, instead of a variable number of arguments based on the array length. 

Looking forward to your feedback.
